### PR TITLE
[wmbus_meter] Stricter meter ID validation

### DIFF
--- a/components/wmbus_meter/__init__.py
+++ b/components/wmbus_meter/__init__.py
@@ -52,7 +52,9 @@ CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(): cv.declare_id(Meter),
         cv.GenerateID(CONF_RADIO_ID): cv.use_id(RadioComponent),
         cv.Required(CONF_METER_ID): cv.All(
-            cv.int_, str, cv.Length(max=8), lambda x: x.zfill(8)
+            cv.int_,
+            lambda x: str(x).zfill(8),
+            cv.Length(max=8),
         ),
         cv.Required(CONF_TYPE): validate_driver,
         cv.Optional(CONF_KEY): cv.Any(

--- a/components/wmbus_meter/__init__.py
+++ b/components/wmbus_meter/__init__.py
@@ -51,7 +51,9 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(Meter),
         cv.GenerateID(CONF_RADIO_ID): cv.use_id(RadioComponent),
-        cv.Required(CONF_METER_ID): cv.All(cv.int_, lambda x: str(x).zfill(8)),
+        cv.Required(CONF_METER_ID): cv.All(
+            cv.int_, str, cv.Length(max=8), lambda x: x.zfill(8)
+        ),
         cv.Required(CONF_TYPE): validate_driver,
         cv.Optional(CONF_KEY): cv.Any(
             cv.All(cv.string_strict, lambda s: s.encode().hex(), hex_key_validator),


### PR DESCRIPTION
This pull request modifies the validation logic for meter IDs. The change ensures stricter validation by adding a length constraint.