### PR TITLE
[wmbus_meter] Meter IDs validation fix

### DIFF
--- a/test.yaml
+++ b/test.yaml
@@ -45,7 +45,7 @@ wmbus_radio:
 
 wmbus_meter:
   id: test_meter
-  meter_id: "12345678"
+  meter_id: 012abcd
   type: apator162
   on_telegram:
     - wmbus_meter.send_telegram_with_mqtt:


### PR DESCRIPTION
* Added `meter_id_validator` to validate and normalize meter IDs as hexadecimal strings, ensuring they are between 1 and 8 characters, positive, and properly formatted.
* Updated the `meter_id` value in `test.yaml` to use a valid hexadecimal format (`012abcd`) in accordance with the new `meter_id_validator`.