### PR TITLE
Increase RX timeout

### DIFF
--- a/components/wmbus_radio/transceiver.cpp
+++ b/components/wmbus_radio/transceiver.cpp
@@ -20,7 +20,7 @@ namespace esphome
                 auto byte = this->read();
                 if (byte.has_value())
                     *buffer++ = *byte;
-                else if (!ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(1)))
+                else if (!ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(5)))
                     return false;
                 else
                     wait_count++;


### PR DESCRIPTION
In some cases 1ms is not enough to receive next part of datagram. Increasing this value allows to receive more valid packets.
But with 1000kbps link, during 1ms we should get at least 12.5 byte of data, so why it helps? idk