### PR TITLE
fix calculating C1 frames size

### DIFF
--- a/components/wmbus_radio/packet.cpp
+++ b/components/wmbus_radio/packet.cpp
@@ -116,8 +116,10 @@ size_t Packet::expected_size() {
           default:
             break;
         }
+        break;
       case LinkMode::T1:
         this->expected_size_ = encoded_size(nrBytes);
+        break;
       default:
         break;
     }


### PR DESCRIPTION
After latest C1 frame handling fixes & refactor, bug in calculating C1 frames size was introduced. 