### PR TITLE
(wmbus_radio) Fix notification timeout tick quantization in SX1276

### DIFF
--- a/components/wmbus_radio/transceiver_sx1276.cpp
+++ b/components/wmbus_radio/transceiver_sx1276.cpp
@@ -89,7 +89,7 @@ void SX1276::setup() {
 bool IRAM_ATTR SX1276::read(uint8_t *buffer, size_t length) {
   while (length > 0) {
     if (this->irq_pin_->digital_read()) {
-      if (!ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(1))) {
+      if (!ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(2))) {
         return false;
       }
     }


### PR DESCRIPTION
```
ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(1))
```
timeouts on the next system tick, so it may occurs faster than next bytes come to the radio (faster than 80us quant)