### PR TITLE
(wmbus_common) Don't assign "?" unit to sensors of fields without unit suffix

### DIFF
--- a/components/wmbus_common/driver_loader/units.py
+++ b/components/wmbus_common/driver_loader/units.py
@@ -42,4 +42,4 @@ def split_name_unit(field_with_suffix):
 
 def get_human_readable_unit(field_unit: str):
     _, unit = split_name_unit(field_unit)
-    return units_dict().get(unit.lower(), unit)
+    return units_dict().get(unit.lower(), unit and "?")

--- a/components/wmbus_common/driver_loader/units.py
+++ b/components/wmbus_common/driver_loader/units.py
@@ -42,4 +42,4 @@ def split_name_unit(field_with_suffix):
 
 def get_human_readable_unit(field_unit: str):
     _, unit = split_name_unit(field_unit)
-    return units_dict().get(unit.lower(), unit or "?")
+    return units_dict().get(unit.lower(), unit)

--- a/components/wmbus_meter/sensor.py
+++ b/components/wmbus_meter/sensor.py
@@ -21,7 +21,8 @@ RegularSensor = wmbus_meter_ns.class_("Sensor", BaseSensor, sensor.Sensor)
 
 def default_unit_of_measurement(config):
     if CONF_UNIT_OF_MEASUREMENT not in config:
-        config[CONF_UNIT_OF_MEASUREMENT] = get_human_readable_unit(config[CONF_FIELD])
+        if unit := get_human_readable_unit(config[CONF_FIELD]):
+            config[CONF_UNIT_OF_MEASUREMENT] = unit
     return config
 
 

--- a/components/wmbus_meter/sensor.py
+++ b/components/wmbus_meter/sensor.py
@@ -21,8 +21,7 @@ RegularSensor = wmbus_meter_ns.class_("Sensor", BaseSensor, sensor.Sensor)
 
 def default_unit_of_measurement(config):
     if CONF_UNIT_OF_MEASUREMENT not in config:
-        if unit := get_human_readable_unit(config[CONF_FIELD]):
-            config[CONF_UNIT_OF_MEASUREMENT] = unit
+        config[CONF_UNIT_OF_MEASUREMENT] = get_human_readable_unit(config[CONF_FIELD])
     return config
 
 

--- a/tests/wmbus.yaml
+++ b/tests/wmbus.yaml
@@ -56,3 +56,9 @@ sensor:
     field: total_m3
     name: "Test Water Consumption"
 
+  - platform: wmbus_meter
+    id: test_timestamp_sensor
+    parent_id: test_meter
+    field: timestamp
+    name: "Test Last Update"
+    device_class: timestamp


### PR DESCRIPTION
## Problem

As described in #55: for well-known fields without a unit suffix (e.g. `timestamp`), the auto-detected `unit_of_measurement` fell back to `"?"`.

Home Assistant treats any sensor with a unit of measurement as numeric, while its ESPHome integration delivers a `datetime` value for `device_class: timestamp` sensors. This conflict makes HA reject every state update, so the entity stays **unavailable** forever. The only workaround was an explicit `unit_of_measurement: ""` in the user's YAML.

## Fix

- `get_human_readable_unit()` returns an empty string instead of `"?"` when no unit can be inferred from the field name (the function has a single call site, so this is safe),
- `default_unit_of_measurement()` skips setting `unit_of_measurement` entirely in that case.

Fields with a proper unit suffix (`_kwh`, `_m3`, `_dbm`, …) are unaffected — the only behavioral change is for fields that previously got the question mark.

Also added a `field: timestamp` sensor with `device_class: timestamp` to `tests/wmbus.yaml` to cover this case.

Fixes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)